### PR TITLE
dockerfileの分離

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,11 +1,11 @@
-FROM rails:onbuild
+FROM eiel/parkmap:bundle
 
-ENV POSTGRES_USER postgres
-ENV POSTGRES_PASSWORD password
+COPY . /usr/src/app
 
-RUN apt-get update && apt-get -y install npm && rm -rf /var/lib/apt/lists/*
+RUN bundle install
 RUN npm install
 RUN nodejs node_modules/gulp/bin/gulp.js build --production
 RUN rake assets:precompile
 
+EXPOSE 3000
 CMD ["rails", "server", "-b", "0.0.0.0"]

--- a/bin/docker_push
+++ b/bin/docker_push
@@ -2,10 +2,12 @@
 
 IMAGE_NAME="eiel/parkmap"
 
+IMAGE_NAME_BUILD="build_${CIRCLE_BUILD_NUM}"
 IMAGE_NAME_SHA=$IMAGE_NAME:COMMIT_$(git rev-parse HEAD)
 IMAGE_NAME_BRANCH=$IMAGE_NAME:$(git rev-parse --abbrev-ref HEAD)
 
 docker login -e $DOCKER_EMAIL -u $DOCKER_USER -p $DOCKER_PASS
+docker tag $IMAGE_NAME $IMAGE_NAME_BUILD
 docker tag $IMAGE_NAME $IMAGE_NAME_SHA
 docker tag $IMAGE_NAME $IMAGE_NAME_BRANCH
 docker push $IMAGE_NAME_SHA $IMAGE_NAME_BRANCH

--- a/dockerfiles/bundle
+++ b/dockerfiles/bundle
@@ -1,0 +1,20 @@
+FROM ruby:2.2.0
+
+RUN apt-get update && apt-get install -y nodejs npm --no-install-recommends && rm -rf /var/lib/apt/lists/*
+RUN apt-get update && apt-get install -y postgresql-client --no-install-recommends && rm -rf /var/lib/apt/lists/*
+
+# throw errors if Gemfile has been modified since Gemfile.lock
+RUN bundle config --global frozen 1
+
+ENV POSTGRES_USER postgres
+ENV POSTGRES_PASSWORD password
+
+RUN mkdir -p /usr/src/app
+WORKDIR /usr/src/app
+
+# ある程度やっておくことで高速化
+COPY Gemfile /usr/src/app/
+COPY Gemfile.lock /usr/src/app/
+RUN bundle install
+COPY package.json /usr/src/app/
+RUN npm install


### PR DESCRIPTION
CIの実行が長いので bundle install や npm installしたイメージを
eiel/parkmap:bundle に分離した。
このイメージを再ビルドするには docker-build ブランチをCIで回せばいい。
新しいイメージを用意しなくても動くようにはなっているはず。
