### PR TITLE
クエリが複数はしってしまってるので includes を追加

### DIFF
--- a/app/controllers/home_controller.rb
+++ b/app/controllers/home_controller.rb
@@ -3,6 +3,6 @@ class HomeController < ApplicationController
   end
 
   def search
-    @parks = Park.search(params)
+    @parks = Park.search(params).includes(:photos)
   end
 end


### PR DESCRIPTION
検索時に関連モデルの検索するために複数のクエリが走ってしまっていた。
includesを追加してまとめて取得するように修正